### PR TITLE
fix(ingress): disable strict path validation

### DIFF
--- a/src/k8s/ingress.ts
+++ b/src/k8s/ingress.ts
@@ -17,6 +17,11 @@ export const ingress = new k8s.helm.v3.Release('ingress-nginx', {
     controller: {
       config: {
         'force-ssl-redirect': 'true',
+
+        // Disable strict path validation, to work around a bug in ingress-nginx
+        // https://cert-manager.io/docs/releases/release-notes/release-notes-1.18/#acme-http01-challenge-paths-now-use-pathtype-exact-in-ingress-routes
+        // https://github.com/kubernetes/ingress-nginx/issues/11176
+        'strict-validate-path-type': false,
       },
       ingressClassResource: {
         default: 'true',


### PR DESCRIPTION
## Summary
- Disable strict-validate-path-type in ingress-nginx controller to work around a bug affecting cert-manager ACME HTTP01 challenges

## References
- https://cert-manager.io/docs/releases/release-notes/release-notes-1.18/#acme-http01-challenge-paths-now-use-pathtype-exact-in-ingress-routes
- https://github.com/kubernetes/ingress-nginx/issues/11176