### PR TITLE
Add fsGroup comments for MCP PVC mounts

### DIFF
--- a/src/k8s/appDefinitions.ts
+++ b/src/k8s/appDefinitions.ts
@@ -347,8 +347,8 @@ export const apps: AppDefinition[] = [
   })),
 
   // Starling Bank MCP (via mcp-auth-wrapper + hass-oidc-provider)
-  // NB: mcp-auth-wrapper runs as non-root `node` user (uid 1000). If using a PVC, you may need
-  // securityContext: { fsGroup: 1000 } on the pod spec for write access. See bluedotimpact/bluedot#2253.
+  // NB: mcp-auth-wrapper runs as non-root `node` user (uid 1000). If copying this configuration and using a PVC, you may need
+  // securityContext: { fsGroup: 1000 } on the pod spec for write access.
   {
     name: 'starling-bank-mcp',
     targetPort: 3000,
@@ -385,8 +385,8 @@ export const apps: AppDefinition[] = [
   },
 
   // OpenFoodFacts MCP (via mcp-auth-wrapper + hass-oidc-provider)
-  // NB: mcp-auth-wrapper runs as non-root `node` user (uid 1000). If using a PVC, you may need
-  // securityContext: { fsGroup: 1000 } on the pod spec for write access. See bluedotimpact/bluedot#2253.
+  // NB: mcp-auth-wrapper runs as non-root `node` user (uid 1000). If copying this configuration and using a PVC, you may need
+  // securityContext: { fsGroup: 1000 } on the pod spec for write access.
   {
     name: 'openfoodfacts-mcp',
     targetPort: 3000,
@@ -485,8 +485,8 @@ export const apps: AppDefinition[] = [
   },
 
   // MCP Aggregator (aggregates all upstream MCP servers behind a single OAuth endpoint)
-  // NB: mcp-aggregator runs as non-root `node` user (uid 1000). If using a PVC, you may need
-  // securityContext: { fsGroup: 1000 } on the pod spec for write access. See bluedotimpact/bluedot#2253.
+  // NB: mcp-aggregator runs as non-root `node` user (uid 1000). If copying this configuration and using a PVC, you may need
+  // securityContext: { fsGroup: 1000 } on the pod spec for write access.
   {
     name: 'mcp-aggregator',
     targetPort: 3000,

--- a/src/k8s/appDefinitions.ts
+++ b/src/k8s/appDefinitions.ts
@@ -347,6 +347,8 @@ export const apps: AppDefinition[] = [
   })),
 
   // Starling Bank MCP (via mcp-auth-wrapper + hass-oidc-provider)
+  // NB: mcp-auth-wrapper runs as non-root `node` user (uid 1000). If using a PVC, you may need
+  // securityContext: { fsGroup: 1000 } on the pod spec for write access. See bluedotimpact/bluedot#2253.
   {
     name: 'starling-bank-mcp',
     targetPort: 3000,
@@ -383,6 +385,8 @@ export const apps: AppDefinition[] = [
   },
 
   // OpenFoodFacts MCP (via mcp-auth-wrapper + hass-oidc-provider)
+  // NB: mcp-auth-wrapper runs as non-root `node` user (uid 1000). If using a PVC, you may need
+  // securityContext: { fsGroup: 1000 } on the pod spec for write access. See bluedotimpact/bluedot#2253.
   {
     name: 'openfoodfacts-mcp',
     targetPort: 3000,
@@ -481,6 +485,8 @@ export const apps: AppDefinition[] = [
   },
 
   // MCP Aggregator (aggregates all upstream MCP servers behind a single OAuth endpoint)
+  // NB: mcp-aggregator runs as non-root `node` user (uid 1000). If using a PVC, you may need
+  // securityContext: { fsGroup: 1000 } on the pod spec for write access. See bluedotimpact/bluedot#2253.
   {
     name: 'mcp-aggregator',
     targetPort: 3000,


### PR DESCRIPTION
## Summary
- Adds comments to `starling-bank-mcp`, `openfoodfacts-mcp`, and `mcp-aggregator` app definitions noting that these images run as non-root `node` user (uid 1000)
- When a Kubernetes PVC is mounted it's owned by root by default, so `securityContext: { fsGroup: 1000 }` is needed on the pod spec for write access
- Discovered when deploying at bluedot — pods were 503ing until fsGroup was added (see bluedotimpact/bluedot#2253)

## Test plan
- [ ] Verify comments are accurate and in the right locations
- [ ] No functional changes — comments only

🤖 Generated with [Claude Code](https://claude.com/claude-code)