### PR TITLE
Use Recreate strategy for zigbee2mqtt

### DIFF
--- a/src/k8s/appDefinitions.ts
+++ b/src/k8s/appDefinitions.ts
@@ -1,4 +1,4 @@
-import { core } from '@pulumi/kubernetes/types/input';
+import { apps as appsTypes, core } from '@pulumi/kubernetes/types/input';
 import {
   haDataPvc, mosquittoConfigmap, ddclientConfigmap, zigbee2mqttDataPvc, esphomeDataPvc, whisperDataPvc, puregymGoogleWalletDataPvc,
   mcpAggregatorDataPvc, starlingBankMcpDataPvc, openfoodfactsMcpDataPvc, musicAssistantDataPvc, haMcpDataPvc,
@@ -88,6 +88,10 @@ export const apps: AppDefinition[] = [
   {
     name: 'zigbee2mqtt',
     targetPort: 8080,
+    // The Zigbee USB stick can only be held by one process at a time. With the default
+    // RollingUpdate, the new pod boots while the old still owns /dev/ttyUSB0 and crashes
+    // with "Cannot lock port" until the old pod terminates.
+    strategy: { type: 'Recreate' },
     spec: {
       containers: [{
         name: 'zigbee2mqtt',
@@ -602,5 +606,6 @@ interface AppDefinition {
   name: string,
   targetPort?: number,
   spec: core.v1.PodSpec,
+  strategy?: appsTypes.v1.DeploymentStrategy,
   ingress?: { host: string, auth: boolean },
 }

--- a/src/k8s/services.ts
+++ b/src/k8s/services.ts
@@ -13,6 +13,7 @@ apps.forEach((app) => {
     spec: {
       selector: { matchLabels: labels },
       replicas: 1,
+      ...(app.strategy ? { strategy: app.strategy } : {}),
       template: {
         metadata: { labels },
         spec: app.spec,


### PR DESCRIPTION
## Summary
- z2m owns `/dev/ttyUSB0` exclusively. Under the default `RollingUpdate`, the new pod boots while the old one still holds the device and crashes with `Resource temporarily unavailable Cannot lock port` until the old pod terminates.
- Switching to `Recreate` makes Kubernetes terminate the old pod first, so the USB stick is free when the new one starts. Brief downtime (~seconds) on rollout, but no crash-loop.
- Adds an optional `strategy` field to the `AppDefinition` shape so other single-hardware-replica apps can opt in if needed.

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test`
- [ ] Pulumi deploy applies cleanly
- [ ] Trigger a rollout (`kubectl rollout restart deployment/zigbee2mqtt-deployment`); old pod terminates fully before new pod starts; new pod reaches `Ready 1/1` without "Cannot lock port" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)