### PR TITLE
Add second Gmail upstream (gmail-2) to mcp-aggregator

### DIFF
--- a/src/k8s/appDefinitions.ts
+++ b/src/k8s/appDefinitions.ts
@@ -600,6 +600,7 @@ export const apps: AppDefinition[] = [
             },
             upstreams: [
               { name: 'gmail', url: `https://gmail.mcp.${env.BASE_DOMAIN}/mcp` },
+              { name: 'gmail-2', url: `https://gmail.mcp.${env.BASE_DOMAIN}/mcp` },
               { name: 'google-cal', url: `https://google-cal.mcp.${env.BASE_DOMAIN}/mcp` },
               { name: 'google-contacts', url: `https://google-contacts.mcp.${env.BASE_DOMAIN}/mcp` },
               { name: 'google-documents', url: `https://google-documents.mcp.${env.BASE_DOMAIN}/mcp` },


### PR DESCRIPTION
Adds a second Gmail upstream to the mcp-aggregator config, pointing at the same gmail-mcp URL under the name `gmail-2`. This lets a second Google account be authorized side-by-side without affecting the existing `gmail` upstream (auth is keyed by upstream name). Requested by Adam over email; named `gmail-2` per Malena's preference.