### PR TITLE
Add workflow_dispatch action to restart a service

### DIFF
--- a/.github/workflows/restart.yaml
+++ b/.github/workflows/restart.yaml
@@ -1,0 +1,47 @@
+name: Restart service
+
+# Restarts a deployment in the cluster, e.g. so an MCP server running
+# `npx -y <package>` picks up the latest published package version.
+# Trigger from the Actions tab, or:
+#   gh workflow run restart.yaml -f service=google-drive-mcp
+on:
+  workflow_dispatch:
+    inputs:
+      service:
+        description: Service name from appDefinitions.ts (e.g. google-drive-mcp)
+        required: true
+        type: string
+
+jobs:
+  restart:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Validate service name
+        run: |
+          if ! echo "$SERVICE" | grep -Eq '^[a-z0-9-]+$'; then
+            echo "Invalid service name: $SERVICE"
+            exit 1
+          fi
+        env:
+          SERVICE: ${{ inputs.service }}
+      - name: Setup WARP for IPv6 connectivity
+        # Pinned to the v1.1 commit because this third-party action runs with the kubeconfig secret in scope
+        uses: fscarmen/warp-on-actions@e8640954f3b22c9e96e63f9ea9cae5df032f40d3
+      - name: Configure kubeconfig
+        run: |
+          mkdir -p ~/.kube
+          echo "$KUBECONFIG" > ~/.kube/config
+        env:
+          KUBECONFIG: ${{ secrets.KUBECONFIG }}
+      - name: Restart deployment
+        run: |
+          if ! kubectl get deployment "$SERVICE-deployment" > /dev/null 2>&1; then
+            echo "Deployment $SERVICE-deployment not found. Available deployments:"
+            kubectl get deployments -o name | sed -e 's|deployment.apps/||' -e 's|-deployment$||'
+            exit 1
+          fi
+          kubectl rollout restart deployment "$SERVICE-deployment"
+          kubectl rollout status deployment "$SERVICE-deployment" --timeout=5m
+        env:
+          SERVICE: ${{ inputs.service }}

--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ Automatically deployed via GitHub CI.
 
 Add a block to [`appDefinitions.ts`](./src/k8s/appDefinitions.ts).
 
+## Restarting a service
+
+Useful e.g. to get an MCP server running `npx -y <package>` to pick up the latest published version, without needing kubectl access.
+
+Run the [Restart service workflow](https://github.com/domdomegg/homelab/actions/workflows/restart.yaml) from the Actions tab, or:
+
+```bash
+gh workflow run restart.yaml -f service=google-drive-mcp
+```
+
+The service name is the `name` from [`appDefinitions.ts`](./src/k8s/appDefinitions.ts).
+
 ## Local development
 
 1. Install Node.js


### PR DESCRIPTION
Adds a manually-triggered GitHub Actions workflow that restarts a deployment in the cluster, so services can be bounced from anywhere (GitHub UI or `gh workflow run restart.yaml -f service=google-drive-mcp`) without needing kubectl access on a particular machine.

Main use case: MCP servers run `npx -y <package>`, so a pod restart is how they pick up newly published package versions — and Pulumi deploys won't restart them because nothing in the manifest changes.

The workflow reuses the existing `KUBECONFIG` secret and WARP IPv6 setup from the deploy workflow, validates the service name input, and waits for the rollout to complete so a green run means the service is back up. The WARP action is pinned to a commit SHA since it runs with the kubeconfig secret in scope.

Note: workflow_dispatch only becomes triggerable once this is on master, so it can only be tested after merge.