### PR TITLE
docs: note per-person self-serve auth principle for MCP gateway

### DIFF
--- a/src/k8s/appDefinitions.ts
+++ b/src/k8s/appDefinitions.ts
@@ -296,6 +296,13 @@ export const apps: AppDefinition[] = [
     },
     ingress: { host: `music.${env.BASE_DOMAIN}`, auth: true },
   },
+
+  // ── MCP gateway ──
+  // Auth principle for every MCP server behind the aggregator: per-person self-serve auth.
+  // Each user authorizes their own account through the OAuth flow (or supplies their own
+  // per-user token via the auth wrapper) — we never hardcode shared/per-user credentials,
+  // and never put user credentials in a Pulumi secret. App-level OAuth client id/secret is
+  // fine; user-identifying tokens must be self-served, not provisioned by us.
   {
     name: 'hass-oidc-provider',
     targetPort: 3001,


### PR DESCRIPTION
Documents the auth principle shared by every MCP server behind the aggregator: **per-person self-serve auth**.

Each user authorizes their own account via OAuth (or supplies their own per-user token through the auth wrapper). We never hardcode shared/per-user creds or put user credentials in a Pulumi secret. App-level OAuth client id/secret is fine; user-identifying tokens must be self-served.

Comment-only; placed above the gateway grouping (`hass-oidc-provider`) since it applies to all the MCP servers, not one block. Documented because the intended model wasn't obvious from the per-server config alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)