### PR TITLE
feat: register google-workspace MCP twice for a second Google account

### DIFF
--- a/src/k8s/appDefinitions.ts
+++ b/src/k8s/appDefinitions.ts
@@ -658,6 +658,9 @@ export const apps: AppDefinition[] = [
               { name: 'google-maps-places', url: `https://google-maps-places.mcp.${env.BASE_DOMAIN}/mcp` },
               { name: 'google-sheets', url: `https://google-sheets.mcp.${env.BASE_DOMAIN}/mcp` },
               { name: 'google-workspace', url: `https://google-workspace.mcp.${env.BASE_DOMAIN}/mcp` },
+              // Second registration of the same server: a distinct aggregator session so one
+              // person can authorize a second Google account in parallel (cf. gmail/gmail-2).
+              { name: 'google-workspace-2', url: `https://google-workspace.mcp.${env.BASE_DOMAIN}/mcp` },
               { name: 'starling-bank', url: `https://starling-bank.mcp.${env.BASE_DOMAIN}/mcp` },
               { name: 'openfoodfacts', url: `https://openfoodfacts.mcp.${env.BASE_DOMAIN}/mcp` },
               { name: 'olio', url: `https://olio.mcp.${env.BASE_DOMAIN}/mcp` },


### PR DESCRIPTION
Adds a `google-workspace-2` aggregator upstream pointing at the same `google-workspace` server URL, giving it a **distinct aggregator session**.

This lets one person authorize a **second Google account** in parallel with the first. The workspace MCP keys credentials per bearer token, so a single server deployment handles multiple accounts — we just need a second session at the aggregator layer. Mirrors the existing `gmail`/`gmail-2` pattern.

No new server deployment; purely an aggregator config addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)