### PR TITLE
Deploy adamcon: the AdamCon '26 one-to-ones app

### DIFF
--- a/src/k8s/appDefinitions.ts
+++ b/src/k8s/appDefinitions.ts
@@ -2,7 +2,7 @@ import { apps as appsTypes, core } from '@pulumi/kubernetes/types/input';
 import {
   haDataPvc, mosquittoConfigmap, ddclientConfigmap, zigbee2mqttDataPvc, esphomeDataPvc, whisperDataPvc,
   mcpAggregatorDataPvc, starlingBankMcpDataPvc, openfoodfactsMcpDataPvc, olioVolunteerMcpDataPvc, musicAssistantDataPvc, haMcpDataPvc,
-  googleWorkspaceMcpDataPvc, whatsappMcpDataPvc, airtableMcpDataPvc,
+  googleWorkspaceMcpDataPvc, whatsappMcpDataPvc, airtableMcpDataPvc, adamconDataPvc,
 } from './storage';
 import env from '../env/prod';
 
@@ -781,6 +781,52 @@ export const apps: AppDefinition[] = [
       }],
     },
     ingress: { host: `pairdrop.${env.BASE_DOMAIN}`, auth: true },
+  },
+  {
+    name: 'adamcon',
+    targetPort: 3000,
+    // Single replica on a RWO volume: replace, don't roll
+    strategy: { type: 'Recreate' },
+    spec: {
+      serviceAccountName: 'adamcon',
+      containers: [{
+        name: 'adamcon',
+        image: 'ghcr.io/domdomegg/adamcon:latest',
+        imagePullPolicy: 'Always',
+        env: [
+          { name: 'APP_ORIGIN', value: `https://adamcon.${env.BASE_DOMAIN}` },
+          { name: 'EMAIL_FROM', value: 'AdamCon <adamcon@adamjones.me>' },
+          { name: 'AWS_REGION', value: 'eu-west-1' },
+          { name: 'AWS_ROLE_ARN', value: 'arn:aws:iam::338337944728:role/adamcon' },
+          { name: 'AWS_WEB_IDENTITY_TOKEN_FILE', value: '/var/run/secrets/aws/token' },
+        ],
+        volumeMounts: [
+          { name: 'adamcon-data-volume', mountPath: '/data' },
+          { name: 'aws-token', mountPath: '/var/run/secrets/aws', readOnly: true },
+        ],
+      }],
+      volumes: [
+        {
+          name: 'adamcon-data-volume',
+          persistentVolumeClaim: {
+            claimName: adamconDataPvc.metadata.name,
+          },
+        },
+        {
+          name: 'aws-token',
+          projected: {
+            sources: [{
+              serviceAccountToken: {
+                audience: 'sts.amazonaws.com',
+                expirationSeconds: 3600,
+                path: 'token',
+              },
+            }],
+          },
+        },
+      ],
+    },
+    ingress: { host: `adamcon.${env.BASE_DOMAIN}`, auth: false },
   },
 ];
 

--- a/src/k8s/oidcDiscovery.ts
+++ b/src/k8s/oidcDiscovery.ts
@@ -139,3 +139,11 @@ new k8s.networking.v1.Ingress('oidc-discovery-ingress', {
     }],
   },
 }, { provider, dependsOn: [ingress] });
+
+// The adamcon app's identity: AWS trusts tokens for this service account
+// (role arn:aws:iam::338337944728:role/adamcon, SES-send only).
+export const adamconServiceAccount = new k8s.core.v1.ServiceAccount('adamcon-sa', {
+  metadata: {
+    name: 'adamcon',
+  },
+}, { provider });

--- a/src/k8s/storage.ts
+++ b/src/k8s/storage.ts
@@ -337,3 +337,20 @@ export const googleWorkspaceMcpDataPvc = new k8s.core.v1.PersistentVolumeClaim('
     },
   },
 }, { provider, replaceOnChanges: ['*'], deleteBeforeReplace: true });
+
+export const adamconDataPvc = new k8s.core.v1.PersistentVolumeClaim('adamcon-data-pvc', {
+  metadata: {
+    name: 'adamcon-data-pvc',
+    annotations: {
+      'pulumi.com/skipAwait': 'true',
+    },
+  },
+  spec: {
+    accessModes: ['ReadWriteOnce'],
+    resources: {
+      requests: {
+        storage: '1Gi',
+      },
+    },
+  },
+}, { provider, replaceOnChanges: ['*'], deleteBeforeReplace: true });


### PR DESCRIPTION
One app block + PVC + ServiceAccount for [domdomegg/adamcon](https://github.com/domdomegg/adamcon). Uses the WIF setup from #285 for keyless SES sending. Already deployed via pulumi through the tunnel and serving at https://adamcon.home.adamjones.me — merging makes master match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)