### PR TITLE
CI: assume AWS via GitHub OIDC instead of long-lived keys

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,10 @@ name: CI/CD
 
 on: push
 
+permissions:
+  id-token: write   # mint the GitHub OIDC token used to assume the AWS role
+  contents: read
+
 jobs:
   ci_cd:
     runs-on: ubuntu-latest
@@ -13,14 +17,16 @@ jobs:
       CI: true
     steps:
       - name: Checkout ${{ github.sha }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: https://registry.npmjs.org/
       - name: Install Pulumi
-        run: curl -fsSL https://get.pulumi.com | sh
+        run: |
+          curl -fsSL https://get.pulumi.com | sh
+          echo "$HOME/.pulumi/bin" >> "$GITHUB_PATH"
       - name: Install NPM dependencies
         run: npm ci
       - name: Lint
@@ -29,16 +35,22 @@ jobs:
         run: npm run build --if-present
       - name: Test
         run: npm run test --if-present
-      
+
       - name: Setup WARP for IPv6 connectivity
         if: github.ref == 'refs/heads/master'
         uses: fscarmen/warp-on-actions@v1.1
+      # AWS access via GitHub OIDC federation — no stored AWS keys. Assumes the
+      # homelab-ci role defined in aws-shared-infra (grants S3 for Pulumi state +
+      # scoped IAM for homelab's app roles / cluster OIDC provider).
+      - name: Configure AWS credentials (OIDC)
+        if: github.ref == 'refs/heads/master'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::338337944728:role/homelab-ci
+          aws-region: eu-west-1
       - name: Configure for deployment
         if: github.ref == 'refs/heads/master'
         run: |
-          mkdir -p ~/.aws
-          echo "$AWS_CONFIG" > ~/.aws/config
-          echo "$AWS_CREDENTIALS" > ~/.aws/credentials
           pulumi login s3://domdomegg-pulumi-backend/homelab
 
           mkdir -p ~/.kube
@@ -46,8 +58,6 @@ jobs:
 
           echo "$PROD_ENV" > src/env/prod.ts
         env:
-          AWS_CONFIG: ${{ secrets.AWS_CONFIG }}
-          AWS_CREDENTIALS: ${{ secrets.AWS_CREDENTIALS }}
           KUBECONFIG: ${{ secrets.KUBECONFIG }}
           PROD_ENV: ${{ secrets.PROD_ENV }}
       - id: later_runs_check


### PR DESCRIPTION
Switches homelab's CI from the long-lived `AWS_CREDENTIALS`/`AWS_CONFIG` GitHub secrets to **GitHub OIDC federation**, assuming the `homelab-ci` role defined in [domdomegg/aws-shared-infra](https://github.com/domdomegg/aws-shared-infra).

## Changes
- Add `permissions: id-token: write` and an `aws-actions/configure-aws-credentials@v4` step assuming `arn:aws:iam::338337944728:role/homelab-ci`.
- Drop the `mkdir ~/.aws` + `AWS_CONFIG`/`AWS_CREDENTIALS` secret writes.
- Add `pulumi` to `$GITHUB_PATH` after `curl | sh` (it isn't set otherwise → `pulumi: command not found`), and bump `checkout`/`setup-node` to v4.
- `KUBECONFIG` and `PROD_ENV` secrets are unchanged (separate follow-ups: kubectl→OIDC, and the PROD_ENV audit).

## Validated
`homelab-ci`'s scoping was checked with `iam:simulate-principal-policy`:
- S3 state read/write under `homelab/*` → allowed
- `iam:CreateRole` on `role/homelab-app-*` **with** the permissions boundary → allowed; **without** it → implicitDeny (escalation guard works)
- cluster OIDC provider management → allowed

## After merge
Delete the now-unused secrets:
```
gh secret delete AWS_CONFIG --repo domdomegg/homelab
gh secret delete AWS_CREDENTIALS --repo domdomegg/homelab
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)