### PR TITLE
Manage adamcon's AWS role + cluster OIDC provider as IaC

### DIFF
--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -1,1 +1,3 @@
 encryptionsalt: v1:QXgZxNBd40w=:v1:KwYy2IeqRHr5viVM:FBvUPRs6PO8CF/nhVB29yfvgYTbcUQ==
+config:
+  aws:region: eu-west-1

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@pulumi/aws": "^7.35.0",
         "@pulumi/kubernetes": "^4.25.0",
         "@pulumi/pulumi": "^3.217.1"
       },
@@ -1154,6 +1155,16 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
       "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@pulumi/aws": {
+      "version": "7.35.0",
+      "resolved": "https://registry.npmjs.org/@pulumi/aws/-/aws-7.35.0.tgz",
+      "integrity": "sha512-DiU5/71xNgyi+o/Vef2k678syNM8PdsoxOEQyVT+aFhWkiiN9JyNLSqpvGZiV8hO1h7mW64mDoDSbJbHCViUww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@pulumi/pulumi": "^3.142.0",
+        "mime": "^2.0.0"
+      }
     },
     "node_modules/@pulumi/kubernetes": {
       "version": "4.25.0",
@@ -5434,6 +5445,18 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/mimic-response": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "deploy:prod": "PULUMI_CONFIG_PASSPHRASE=unused pulumi up --stack prod --yes"
   },
   "dependencies": {
+    "@pulumi/aws": "^7.35.0",
     "@pulumi/kubernetes": "^4.25.0",
     "@pulumi/pulumi": "^3.217.1"
   },

--- a/src/aws/adamconRole.ts
+++ b/src/aws/adamconRole.ts
@@ -1,0 +1,47 @@
+import * as aws from '@pulumi/aws';
+import { clusterOidcProvider } from './clusterOidcProvider';
+
+const ACCOUNT_ID = '338337944728';
+
+// Permissions boundary that every homelab app role must carry (defined in
+// aws-shared-infra). homelab-ci is only allowed to create/manage app roles that
+// have it attached, so it can't escalate them beyond the SES-send ceiling.
+const APP_ROLE_BOUNDARY_ARN = `arn:aws:iam::${ACCOUNT_ID}:policy/homelab-app-role-boundary`;
+
+// The AWS role the adamcon app assumes (via the cluster OIDC provider) to send
+// email through SES. Named homelab-app-* so aws-shared-infra's homelab-ci grant
+// (scoped to role/homelab-app-*) can manage it. The k8s app / service account
+// stays named 'adamcon', so the trust sub is unchanged.
+export const adamconRole = new aws.iam.Role('adamcon', {
+  name: 'homelab-app-adamcon',
+  description: 'SES-send role for the adamcon app; assumed via the k3s cluster OIDC provider.',
+  permissionsBoundary: APP_ROLE_BOUNDARY_ARN,
+  assumeRolePolicy: clusterOidcProvider.arn.apply((providerArn) => JSON.stringify({
+    Version: '2012-10-17',
+    Statement: [{
+      Effect: 'Allow',
+      Principal: { Federated: providerArn },
+      Action: 'sts:AssumeRoleWithWebIdentity',
+      Condition: {
+        StringEquals: {
+          'k8s-oidc.home.adamjones.me:aud': 'sts.amazonaws.com',
+          'k8s-oidc.home.adamjones.me:sub': 'system:serviceaccount:default:adamcon',
+        },
+      },
+    }],
+  })),
+});
+
+new aws.iam.RolePolicy('adamcon-ses-send', {
+  name: 'adamcon-ses-send',
+  role: adamconRole.name,
+  policy: JSON.stringify({
+    Version: '2012-10-17',
+    Statement: [{
+      Sid: 'AdamconSesSend',
+      Effect: 'Allow',
+      Action: ['ses:SendEmail', 'ses:SendRawEmail'],
+      Resource: `arn:aws:ses:eu-west-1:${ACCOUNT_ID}:identity/adamjones.me`,
+    }],
+  }),
+});

--- a/src/aws/clusterOidcProvider.ts
+++ b/src/aws/clusterOidcProvider.ts
@@ -1,0 +1,19 @@
+import * as aws from '@pulumi/aws';
+
+// The k3s cluster's OIDC issuer, so AWS can federate against cluster
+// service-account tokens (the adamcon app assumes an SES-send role via it).
+// Lives here — next to the cluster and the app that use it — rather than in the
+// account-level aws-shared-infra repo.
+//
+// IMPORTED (created out-of-band, then moved out of aws-shared-infra's state):
+//   pulumi import aws:iam/openIdConnectProvider:OpenIdConnectProvider cluster-oidc \
+//     arn:aws:iam::338337944728:oidc-provider/k8s-oidc.home.adamjones.me
+//
+// Fields must match AWS exactly. The AWS provider's validator wants a scheme on
+// `url` but the stored value has none; 'https://…' both validates and matches
+// the import (Pulumi normalizes), so it does NOT trigger a replacement.
+export const clusterOidcProvider = new aws.iam.OpenIdConnectProvider('cluster-oidc', {
+  url: 'https://k8s-oidc.home.adamjones.me',
+  clientIdLists: ['sts.amazonaws.com'],
+  thumbprintLists: ['ab9d0263244dd0326eb67015705a667e79cfe998'],
+});

--- a/src/aws/index.ts
+++ b/src/aws/index.ts
@@ -1,0 +1,2 @@
+import './clusterOidcProvider';
+import './adamconRole';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
+import './aws';
 import './k8s';

--- a/src/k8s/appDefinitions.ts
+++ b/src/k8s/appDefinitions.ts
@@ -849,9 +849,10 @@ export const apps: AppDefinition[] = [
   },
   {
     // AWS trusts tokens for this app's generated service account, named
-    // 'adamcon' after the app (role arn:aws:iam::338337944728:role/adamcon,
-    // SES-send only) — renaming the app changes the token's sub claim and
-    // breaks that trust policy.
+    // 'adamcon' after the app (role homelab-app-adamcon, SES-send only; see
+    // src/aws/adamconRole.ts) — renaming the k8s app changes the token's sub
+    // claim and breaks that trust policy, so keep the app name 'adamcon' even
+    // though the AWS role is prefixed homelab-app-*.
     name: 'adamcon',
     targetPort: 3000,
     // Single replica on a RWO volume: replace, don't roll
@@ -869,7 +870,7 @@ export const apps: AppDefinition[] = [
           { name: 'APP_ORIGIN', value: `https://adamcon.${env.BASE_DOMAIN}` },
           { name: 'EMAIL_FROM', value: 'AdamCon <adamcon@adamjones.me>' },
           { name: 'AWS_REGION', value: 'eu-west-1' },
-          { name: 'AWS_ROLE_ARN', value: 'arn:aws:iam::338337944728:role/adamcon' },
+          { name: 'AWS_ROLE_ARN', value: 'arn:aws:iam::338337944728:role/homelab-app-adamcon' },
           { name: 'AWS_WEB_IDENTITY_TOKEN_FILE', value: '/var/run/secrets/aws/token' },
         ],
         volumeMounts: [


### PR DESCRIPTION
Steps 4+5 of the WIF migration: bring the adamcon app's AWS-side IAM under homelab's Pulumi.

## Changes
- **New `src/aws/` module** (adds `@pulumi/aws` v7):
  - `cluster-oidc` — imports the k3s cluster OIDC provider (`k8s-oidc.home.adamjones.me`), moved out of `aws-shared-infra` to live next to the cluster/app that use it.
  - `homelab-app-adamcon` — the SES-send role, renamed from `adamcon` to the `homelab-app-*` prefix that `aws-shared-infra`'s `homelab-ci` grant manages. Carries the `homelab-app-role-boundary` permissions boundary; identical trust (`sub system:serviceaccount:default:adamcon`) and SES policy.
- Point the adamcon pod's `AWS_ROLE_ARN` at `homelab-app-adamcon`.
- Set `aws:region` for the stack.

## Sequencing / behavior
- Creates `homelab-app-adamcon` + points the pod at it. The **old standalone `adamcon` role is deleted out-of-band after merge** (can't be Pulumi-deleted — it's not in state).
- **Email sending is briefly interrupted** between the pod switching ARNs and the new role existing. The adamcon app is unused, so this is acceptable.
- Verified: the `homelab-app-role-boundary` allows `ses:SendEmail`/`SendRawEmail`, so the role's effective perms still permit SES under the ceiling.

## ⚠️ Unrelated drift riding along
This deploy also reconciles **pre-existing** drift I did not introduce: the `cert-manager-issuer` ClusterIssuer gets a cosmetic `namespace: cert-manager` added (it's in the committed code but missing from deployed state). ClusterIssuers are cluster-scoped so namespace is ignored; existing certs stay valid (issuer is `Ready`, all 29 certs ready). Pulumi models it as a replace, but it's benign. Flagging so it's not a surprise in the deploy log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)