### PR TITLE
CI: authenticate kubectl via GitHub OIDC (kill KUBECONFIG admin cert)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,17 +48,32 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::338337944728:role/homelab-ci
           aws-region: eu-west-1
+      # Build a kubeconfig that authenticates via a GitHub OIDC token instead of
+      # the old cluster-admin cert (KUBECONFIG secret). The apiserver trusts
+      # this repo's master-ref token (audience homelab-k8s) and maps it to a
+      # cluster-admin-bound user (see src/k8s/ciRbac.ts). CA + server are
+      # non-secret repo variables; tls-server-name=kubernetes because the cert's
+      # SANs don't include home.adamjones.me.
       - name: Configure for deployment
         if: github.ref == 'refs/heads/master'
         run: |
           pulumi login s3://domdomegg-pulumi-backend/homelab
 
+          K8S_TOKEN=$(curl -sf -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=homelab-k8s" | python3 -c 'import sys,json;print(json.load(sys.stdin)["value"])')
+
           mkdir -p ~/.kube
-          echo "$KUBECONFIG" > ~/.kube/config
+          kubectl config set-cluster homelab --server="$KUBE_SERVER" --tls-server-name=kubernetes >/dev/null
+          echo "$KUBE_CA_DATA" | base64 -d > /tmp/k8s-ca.crt
+          kubectl config set-cluster homelab --certificate-authority=/tmp/k8s-ca.crt --embed-certs=true >/dev/null
+          kubectl config set-credentials github-ci --token="$K8S_TOKEN" >/dev/null
+          kubectl config set-context homelab --cluster=homelab --user=github-ci >/dev/null
+          kubectl config use-context homelab >/dev/null
 
           echo "$PROD_ENV" > src/env/prod.ts
         env:
-          KUBECONFIG: ${{ secrets.KUBECONFIG }}
+          KUBE_SERVER: ${{ vars.KUBE_SERVER }}
+          KUBE_CA_DATA: ${{ vars.KUBE_CA_DATA }}
           PROD_ENV: ${{ secrets.PROD_ENV }}
       - id: later_runs_check
         name: Check for later runs

--- a/src/k8s/ciRbac.ts
+++ b/src/k8s/ciRbac.ts
@@ -1,0 +1,31 @@
+import * as k8s from '@pulumi/kubernetes';
+import { provider } from './provider';
+
+// RBAC for GitHub-Actions-federated CI. The apiserver is configured (via
+// /etc/rancher/k3s/github-oidc-auth.yaml) to trust GitHub OIDC tokens with
+// audience 'homelab-k8s' whose sub is exactly this repo's master ref, mapping
+// them to the username below (prefix 'github:' + the sub claim).
+//
+// This replaces the long-lived cluster-admin kubeconfig (the k3s.yaml that used
+// to live in the KUBECONFIG GitHub secret): CI now presents a short-lived,
+// repo+branch-scoped OIDC token instead of a stealable standing admin cert.
+//
+// Bound to cluster-admin because Pulumi manages helm releases, CRDs, namespaces
+// and cluster-scoped resources — the same scope the admin cert had. The gain is
+// the credential's nature (short-lived, revocable by deleting this binding),
+// not a narrower grant.
+const CI_USERNAME = 'github:repo:domdomegg/homelab:ref:refs/heads/master';
+
+new k8s.rbac.v1.ClusterRoleBinding('github-ci-admin', {
+  metadata: { name: 'github-ci-admin' },
+  roleRef: {
+    apiGroup: 'rbac.authorization.k8s.io',
+    kind: 'ClusterRole',
+    name: 'cluster-admin',
+  },
+  subjects: [{
+    apiGroup: 'rbac.authorization.k8s.io',
+    kind: 'User',
+    name: CI_USERNAME,
+  }],
+}, { provider });

--- a/src/k8s/index.ts
+++ b/src/k8s/index.ts
@@ -3,3 +3,4 @@ import './storage';
 import './certManager';
 import './services';
 import './jobs';
+import './ciRbac';


### PR DESCRIPTION
Step 6: replace the long-lived cluster-admin kubeconfig (`KUBECONFIG` secret) with GitHub OIDC federation for the k8s apiserver.

## How it works
- **Apiserver** (configured out-of-band on the XPS): a structured `AuthenticationConfiguration` trusts GitHub Actions OIDC tokens with audience `homelab-k8s` whose `sub` is exactly `repo:domdomegg/homelab:ref:refs/heads/master`, mapping them to user `github:repo:domdomegg/homelab:ref:refs/heads/master`.
- **RBAC** (`src/k8s/ciRbac.ts`): binds that user to `cluster-admin` — same scope the admin cert had; the win is the credential's nature (short-lived, repo+branch-scoped, revocable by deleting the binding) not a narrower grant.
- **CI**: mints the OIDC token and builds a kubeconfig from it (bearer token + non-secret CA/server repo variables + `tls-server-name=kubernetes`).

## Safety
- The apiserver change **adds** an authenticator — the existing admin cert still works, so tunnel access is unaffected. Verified: apiserver healthy after restart, all 41 pods running, admin kubectl still works.
- The `KUBECONFIG` secret is **kept until this deploys green**, so the old path is a fallback. SSH lifeline is also open as a backstop.
- After a green master deploy: `gh secret delete KUBECONFIG --repo domdomegg/homelab`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)