### PR TITLE
Add PostHog to the MCP aggregator; pin Helm charts

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,6 +13,12 @@
             "fileMatch": ["src/k8s/appDefinitions.ts"],
             "matchStrings": ["('|\\\")(?<depName>[a-z0-9-/.]*?):(?<currentValue>[a-z0-9-/.]*?)@(?<currentDigest>sha256:[0-9a-f]+?)('|\\\")"],
             "datasourceTemplate": "docker"
+        },
+        {
+            "customType": "regex",
+            "fileMatch": ["src/k8s/.*\\.ts$"],
+            "matchStrings": ["renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+) registryUrl=(?<registryUrl>\\S+)\\s+version: '(?<currentValue>[^']+)'"],
+            "versioningTemplate": "helm"
         }
     ],
     "prBodyTemplate": "{{{header}}}{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}",

--- a/src/k8s/appDefinitions.ts
+++ b/src/k8s/appDefinitions.ts
@@ -751,6 +751,7 @@ export const apps: AppDefinition[] = [
               { name: 'tool-sandbox', url: `https://tool-sandbox.mcp.${env.BASE_DOMAIN}/mcp` },
               { name: 'tunnel', url: `https://tunnel.mcp.${env.BASE_DOMAIN}/mcp` },
               { name: 'slack', url: 'https://mcp.slack.com/mcp', clientId: '825862040501.10898174083287' },
+              { name: 'posthog', url: 'https://mcp.posthog.com/mcp' },
             ],
             storage: '/app/data/mcp-aggregator.sqlite',
             issuerUrl: `https://mcp.${env.BASE_DOMAIN}`,

--- a/src/k8s/certManager.ts
+++ b/src/k8s/certManager.ts
@@ -10,6 +10,8 @@ const namespace = new k8s.core.v1.Namespace('cert-manager-namespace', {
 
 const helmRelease = new k8s.helm.v3.Release('cert-manager', {
   chart: 'cert-manager',
+  // renovate: datasource=helm depName=cert-manager registryUrl=https://charts.jetstack.io
+  version: 'v1.20.3',
   repositoryOpts: {
     repo: 'https://charts.jetstack.io',
   },
@@ -24,7 +26,6 @@ new k8s.apiextensions.CustomResource('cert-manager-issuer', {
   kind: 'ClusterIssuer',
   metadata: {
     name: 'cert-manager-issuer',
-    namespace: 'cert-manager',
   },
   spec: {
     acme: {

--- a/src/k8s/ingress.ts
+++ b/src/k8s/ingress.ts
@@ -9,6 +9,8 @@ const namespace = new k8s.core.v1.Namespace('ingress-nginx-namespace', {
 
 export const ingress = new k8s.helm.v3.Release('ingress-nginx', {
   chart: 'ingress-nginx',
+  // renovate: datasource=helm depName=ingress-nginx registryUrl=https://kubernetes.github.io/ingress-nginx
+  version: '4.15.1',
   repositoryOpts: {
     repo: 'https://kubernetes.github.io/ingress-nginx',
   },


### PR DESCRIPTION
## What

Adds PostHog's hosted MCP server (`mcp.posthog.com`) as an upstream on the MCP aggregator, so its tools are available behind the shared OAuth endpoint alongside gmail, slack, airtable, etc.

PostHog exposes a full native OAuth flow (`oauth.posthog.com`, with **dynamic client registration + PKCE**), so it needs nothing more than a bare `{ name, url }` entry — no `mcp-auth-wrapper`, no `mcp-remote` bridge, no PVC, no shared token. Each user self-serves their own PostHog authorization via the OAuth flow, consistent with the aggregator's documented per-person auth principle.

## Drift cleanup (surfaced while deploying the above)

The `pulumi preview` for the PostHog change also showed two pre-existing, unrelated changes. Fixed both so deploys are clean:

- **Unpinned Helm charts.** `cert-manager` and `ingress-nginx` had no `version`, so Pulumi resolved "latest" on every run. `cert-manager` would have silently upgraded **v1.20.3 → v1.21.0** on the next `pulumi up`. Pinned both to their currently-running versions and added a Renovate `custom.regex` manager (`datasource=helm`) so they're auto-bumped like the Docker image digests already are.
- **Inert `namespace` on the `cert-manager-issuer` ClusterIssuer.** ClusterIssuer is cluster-scoped, so the API server drops the field — but its presence in the Pulumi inputs caused a perpetual delete-and-replace diff in every preview. Removed it.

## Verification

- `npm run build` + `npm run lint` pass.
- `pulumi preview` after all changes shows **exactly one** change (the `mcp-aggregator` deployment) — the cert-manager version drift and ClusterIssuer replace are gone.
- **Deployed to prod** over the tunnel. New aggregator pod rolled out cleanly; the aggregator now exposes `gateway__posthog__auth` (the self-serve OAuth entry). The full `posthog__*` toolset appears per-user once each person completes the authorize flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bg6LuF35qWbYT2u5tNBwnm