### PR TITLE
Aggregator reaches in-cluster MCP upstreams via service DNS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1436,9 +1436,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1456,9 +1453,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1476,9 +1470,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1496,9 +1487,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1516,9 +1504,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1536,9 +1521,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5179,9 +5161,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5203,9 +5182,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5227,9 +5203,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5251,9 +5224,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/src/k8s/appDefinitions.ts
+++ b/src/k8s/appDefinitions.ts
@@ -728,34 +728,40 @@ export const apps: AppDefinition[] = [
 							issuer: `https://oidc.${env.BASE_DOMAIN}`,
 							clientId: 'mcp-aggregator',
 						},
+						// In-cluster upstreams use their service DNS names directly: going via
+						// the public hostname hairpins through the ingress and re-does TLS on
+						// every connection (~130ms/request vs ~5ms internal), and the
+						// aggregator connects per call. OAuth still works: the wrappers serve
+						// their discovery metadata on any Host, and the endpoints they
+						// advertise there are the public URLs.
 						upstreams: [
-							{name: 'gmail', url: `https://gmail.mcp.${env.BASE_DOMAIN}/mcp`},
-							{name: 'gmail-2', url: `https://gmail.mcp.${env.BASE_DOMAIN}/mcp`},
-							{name: 'google-cal', url: `https://google-cal.mcp.${env.BASE_DOMAIN}/mcp`},
-							{name: 'google-contacts', url: `https://google-contacts.mcp.${env.BASE_DOMAIN}/mcp`},
-							{name: 'google-documents', url: `https://google-documents.mcp.${env.BASE_DOMAIN}/mcp`},
-							{name: 'google-drive', url: `https://google-drive.mcp.${env.BASE_DOMAIN}/mcp`},
-							{name: 'google-maps-places', url: `https://google-maps-places.mcp.${env.BASE_DOMAIN}/mcp`},
-							{name: 'google-sheets', url: `https://google-sheets.mcp.${env.BASE_DOMAIN}/mcp`},
-							{name: 'google-workspace', url: `https://google-workspace.mcp.${env.BASE_DOMAIN}/mcp`},
+							{name: 'gmail', url: 'http://gmail-mcp-svc/mcp'},
+							{name: 'gmail-2', url: 'http://gmail-mcp-svc/mcp'},
+							{name: 'google-cal', url: 'http://google-cal-mcp-svc/mcp'},
+							{name: 'google-contacts', url: 'http://google-contacts-mcp-svc/mcp'},
+							{name: 'google-documents', url: 'http://google-documents-mcp-svc/mcp'},
+							{name: 'google-drive', url: 'http://google-drive-mcp-svc/mcp'},
+							{name: 'google-maps-places', url: 'http://google-maps-places-mcp-svc/mcp'},
+							{name: 'google-sheets', url: 'http://google-sheets-mcp-svc/mcp'},
+							{name: 'google-workspace', url: 'http://google-workspace-mcp-svc/mcp'},
 							// Second registration of the same server: a distinct aggregator session so one
 							// person can authorize a second Google account in parallel (cf. gmail/gmail-2).
-							{name: 'google-workspace-2', url: `https://google-workspace.mcp.${env.BASE_DOMAIN}/mcp`},
-							{name: 'starling-bank', url: `https://starling-bank.mcp.${env.BASE_DOMAIN}/mcp`},
-							{name: 'airtable', url: `https://airtable.mcp.${env.BASE_DOMAIN}/mcp`},
-							{name: 'openfoodfacts', url: `https://openfoodfacts.mcp.${env.BASE_DOMAIN}/mcp`},
-							{name: 'olio', url: `https://olio.mcp.${env.BASE_DOMAIN}/mcp`},
-							{name: 'benepass', url: `https://benepass.mcp.${env.BASE_DOMAIN}/mcp`},
-							{name: 'barcode-scanner', url: `https://barcode-scanner.mcp.${env.BASE_DOMAIN}/mcp`},
-							{name: 'home-assistant', url: `https://ha.mcp.${env.BASE_DOMAIN}/mcp`},
-							{name: 'whatsapp', url: `https://whatsapp.mcp.${env.BASE_DOMAIN}/mcp`},
+							{name: 'google-workspace-2', url: 'http://google-workspace-mcp-svc/mcp'},
+							{name: 'starling-bank', url: 'http://starling-bank-mcp-svc/mcp'},
+							{name: 'airtable', url: 'http://airtable-mcp-svc/mcp'},
+							{name: 'openfoodfacts', url: 'http://openfoodfacts-mcp-svc/mcp'},
+							{name: 'olio', url: 'http://olio-volunteer-mcp-svc/mcp'},
+							{name: 'benepass', url: 'http://benepass-mcp-svc/mcp'},
+							{name: 'barcode-scanner', url: 'http://barcode-scanner-mcp-svc/mcp'},
+							{name: 'home-assistant', url: 'http://ha-mcp-svc/mcp'},
+							{name: 'whatsapp', url: 'http://whatsapp-mcp-svc/mcp'},
 							// Second registration of the same server: a distinct client id, so it
 							// can be bound to a different mcp-auth-wrapper profile and therefore a
 							// second WhatsApp account — the agent's own number rather than Adam's
 							// (cf. gmail/gmail-2, though that works via per-session OAuth instead).
-							{name: 'whatsapp-claube', url: `https://whatsapp.mcp.${env.BASE_DOMAIN}/mcp`},
-							{name: 'tool-sandbox', url: `https://tool-sandbox.mcp.${env.BASE_DOMAIN}/mcp`},
-							{name: 'tunnel', url: `https://tunnel.mcp.${env.BASE_DOMAIN}/mcp`},
+							{name: 'whatsapp-claube', url: 'http://whatsapp-mcp-svc/mcp'},
+							{name: 'tool-sandbox', url: 'http://tool-sandbox-mcp-svc/mcp'},
+							{name: 'tunnel', url: 'http://mcp-local-tunnel-svc/mcp'},
 							{name: 'slack', url: 'https://mcp.slack.com/mcp', clientId: '825862040501.10898174083287'},
 							{name: 'posthog', url: 'https://mcp.posthog.com/mcp'},
 						],


### PR DESCRIPTION
## Why

Every aggregator→upstream hop went out through the public hostname: a fresh TLS handshake per connection (~35ms/request steady-state vs ~5ms via the cluster service), and the aggregator connects per tool call, so this applied 3-4× to every call. Clients preferring the A record additionally routed via the external relay.

Measured per request from inside the cluster: v4-via-relay ~114ms, direct v6 ~64ms one-shot / ~35ms warm, internal http ~5ms.

## Safety

- Aggregator DB keys tokens and DCR registrations by upstream **name**, not URL (`UNIQUE(user_id, upstream_name)`) — no reauth needed.
- mcp-auth-wrapper serves its RFC 9728/8414 discovery on any Host, advertises **public** endpoint URLs in the metadata, and its sealed tokens are not bound to the transport host (verified in source + live 200s with existing tokens over the internal route).
- slack/posthog stay public (external services).
- tool-sandbox's own `upstream` config stays public so the auth server it advertises to OAuth clients remains reachable (per review on domdomegg/tool-sandbox-mcp#35).

Discussed on WhatsApp — "can change to internal http urls if you want; get that working".

🤖 Generated with [Claude Code](https://claude.com/claude-code)