### PR TITLE
mcp-aggregator: bind dual-stack (host '::')

### DIFF
--- a/src/k8s/appDefinitions.ts
+++ b/src/k8s/appDefinitions.ts
@@ -757,6 +757,10 @@ export const apps: AppDefinition[] = [
 							{name: 'slack', url: 'https://mcp.slack.com/mcp', clientId: '825862040501.10898174083287'},
 							{name: 'posthog', url: 'https://mcp.posthog.com/mcp'},
 						],
+						// Dual-stack bind. The default 0.0.0.0 is IPv4-only, and on this dual-stack
+						// cluster ingress-nginx tries the pod's IPv6 address first: 93% of requests
+						// (1522/1641 in one hour, 2026-08-23) paid a refused connect + retry.
+						host: '::',
 						storage: '/app/data/mcp-aggregator.sqlite',
 						issuerUrl: `https://mcp.${env.BASE_DOMAIN}`,
 						secret: env.MCP_AGGREGATOR_SECRET,


### PR DESCRIPTION
The aggregator binds `0.0.0.0` by default (IPv4-only). The cluster is dual-stack and ingress-nginx tries the pod's IPv6 endpoint first, so nearly every request pays a refused connect and a retry over IPv4:

- ingress log, one hour on 2026-08-23: **1522 of 1641** aggregator requests logged `connect() failed (Connection refused)` against `[fd7d:4ce0:5b35:1::3a]:3000` before succeeding on `10.42.0.58`
- confirmed from inside the cluster: `curl http://[fd7d:…::3a]:3000/…` → refused; `curl http://10.42.0.58:3000/…` → 200 in 0.4ms

`host` is a supported config key (README: "Host to bind to. Defaults to 0.0.0.0"); `'::'` binds both families in Node. One-line change. Likely a chunk of the unexplained ingress latency from earlier today.

`ha-mcp` and `whatsapp-mcp` show the same pattern at low volume (107 and 3 refusals/hour) — separate change if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)