### PR TITLE
Drop music-assistant and its data PVC

### DIFF
--- a/src/k8s/appDefinitions.ts
+++ b/src/k8s/appDefinitions.ts
@@ -1,7 +1,7 @@
 import {type apps as appsTypes, type core} from '@pulumi/kubernetes/types/input';
 import {
 	haDataPvc, mosquittoConfigmap, ddclientConfigmap, zigbee2mqttDataPvc, esphomeDataPvc, whisperDataPvc,
-	mcpAggregatorDataPvc, starlingBankMcpDataPvc, openfoodfactsMcpDataPvc, olioVolunteerMcpDataPvc, musicAssistantDataPvc, haMcpDataPvc,
+	mcpAggregatorDataPvc, starlingBankMcpDataPvc, openfoodfactsMcpDataPvc, olioVolunteerMcpDataPvc, haMcpDataPvc,
 	googleWorkspaceMcpDataPvc, whatsappMcpDataPvc, airtableMcpDataPvc, adamconDataPvc, oidcDiscoveryConfigmap,
 	personalAgentDataPvc,
 } from './storage';
@@ -273,32 +273,6 @@ export const apps: AppDefinition[] = [
 			}],
 		},
 	},
-	{
-		name: 'music-assistant',
-		targetPort: 8095,
-		spec: {
-			// Required for mDNS/Zeroconf device discovery (Chromecast, Sonos, AirPlay, DLNA, Squeezebox)
-			// — multicast doesn't traverse the pod network namespace.
-			hostNetwork: true,
-			dnsPolicy: 'ClusterFirstWithHostNet',
-			containers: [{
-				name: 'music-assistant',
-				image: 'ghcr.io/music-assistant/server:latest@sha256:5500c53c5129bbabfb0de2c2c298fd0ef15fe34207bbe5794f49c587b76bde95',
-				volumeMounts: [{
-					name: 'music-assistant-data-volume',
-					mountPath: '/data',
-				}],
-			}],
-			volumes: [{
-				name: 'music-assistant-data-volume',
-				persistentVolumeClaim: {
-					claimName: musicAssistantDataPvc.metadata.name,
-				},
-			}],
-		},
-		ingress: {host: `music.${env.BASE_DOMAIN}`, auth: true},
-	},
-
 	// ── MCP gateway ──
 	// Auth principle for every MCP server behind the aggregator: per-person self-serve auth.
 	// Each user authorizes their own account through the OAuth flow (or supplies their own

--- a/src/k8s/storage.ts
+++ b/src/k8s/storage.ts
@@ -241,23 +241,6 @@ export const olioVolunteerMcpDataPvc = new k8s.core.v1.PersistentVolumeClaim('ol
 	},
 }, {provider, replaceOnChanges: ['*'], deleteBeforeReplace: true});
 
-export const musicAssistantDataPvc = new k8s.core.v1.PersistentVolumeClaim('music-assistant-data-pvc', {
-	metadata: {
-		name: 'music-assistant-data-pvc',
-		annotations: {
-			'pulumi.com/skipAwait': 'true',
-		},
-	},
-	spec: {
-		accessModes: ['ReadWriteOnce'],
-		resources: {
-			requests: {
-				storage: '5Gi',
-			},
-		},
-	},
-}, {provider, replaceOnChanges: ['*'], deleteBeforeReplace: true});
-
 export const haMcpDataPvc = new k8s.core.v1.PersistentVolumeClaim('ha-mcp-data-pvc', {
 	metadata: {
 		name: 'ha-mcp-data-pvc',


### PR DESCRIPTION
Removes the `music-assistant` app and its `music-assistant-data-pvc` (5Gi, local-path). Frees ~370Mi of RAM.

Why it's safe to remove:
- Home Assistant has the Music Assistant integration entry set to **ignored** (not loaded); no automations, scripts or helpers reference it; no HA media_player entities come from it.
- Spotify control already exists through HA SpotifyPlus (50 services — search, play, queue, transfer to the playbar, playlists), reachable via the home-assistant MCP's `ha_call_service`.
- It is also misbehaving: tonight's log shows `Librespot exited` → `Failed to stream audio` on a play request.

**Destructive:** deleting the PVC discards Music Assistant's library/config data. Adam asked for that explicitly ("you can drop the pvc too").

🤖 Generated with [Claude Code](https://claude.com/claude-code)