### PR TITLE
personal-agent: expose the agent's desktop as desktop.<domain> (noVNC on 6080)

### DIFF
--- a/src/k8s/appDefinitions.ts
+++ b/src/k8s/appDefinitions.ts
@@ -938,6 +938,12 @@ export const apps: AppDefinition[] = [
 		},
 		// The transcript viewer, behind the same auth as the other internal tools.
 		ingress: {host: `agent.${env.BASE_DOMAIN}`, auth: true},
+		// The agent's desktop (Xvfb + Chromium in its container), served as noVNC
+		// on 6080 so Adam can watch or take over a browser session. Auth-gated;
+		// x11vnc itself listens on localhost only.
+		extraIngresses: [{
+			name: 'desktop', targetPort: 6080, host: `desktop.${env.BASE_DOMAIN}`, auth: true,
+		}],
 	},
 ];
 
@@ -947,4 +953,10 @@ type AppDefinition = {
 	spec: core.v1.PodSpec;
 	strategy?: appsTypes.v1.DeploymentStrategy;
 	ingress?: {host: string; auth: boolean};
+	/**
+	 * Further ports on the same pod, each with its own hostname: a second
+	 * Service + Ingress per entry (e.g. the agent's noVNC desktop beside its
+	 * viewer). `name` suffixes the generated resources.
+	 */
+	extraIngresses?: {name: string; targetPort: number; host: string; auth: boolean}[];
 };

--- a/src/k8s/services.ts
+++ b/src/k8s/services.ts
@@ -39,8 +39,9 @@ apps.forEach((app) => {
 		},
 	}, {provider});
 
-	if (app.targetPort) {
-		const service = new k8s.core.v1.Service(`${app.name}-svc`, {
+	/** A ClusterIP Service on the pod, and optionally an Ingress in front of it. */
+	const expose = (resourceName: string, targetPort: number, ing?: {host: string; auth: boolean}) => {
+		const service = new k8s.core.v1.Service(`${resourceName}-svc`, {
 			spec: {
 				type: 'ClusterIP',
 				selector: labels,
@@ -48,22 +49,22 @@ apps.forEach((app) => {
 				ports: [{
 					name: 'default',
 					port: 80,
-					targetPort: app.targetPort,
+					targetPort,
 				}],
 			},
 			metadata: {
-				name: `${app.name}-svc`,
+				name: `${resourceName}-svc`,
 			},
 		}, {provider, dependsOn: [deployment]});
 
-		if (app.ingress) {
-			new k8s.networking.v1.Ingress(`${app.name}-ingress`, {
+		if (ing) {
+			new k8s.networking.v1.Ingress(`${resourceName}-ingress`, {
 				metadata: {
-					name: `${app.name}-ingress`,
+					name: `${resourceName}-ingress`,
 					annotations: {
 						'kubernetes.io/ingress.class': 'nginx',
 						'cert-manager.io/cluster-issuer': 'cert-manager-issuer',
-						...(app.ingress.auth
+						...(ing.auth
 							? {
 								'nginx.ingress.kubernetes.io/auth-signin': `https://vouch.${env.BASE_DOMAIN}/login?url=$scheme://$http_host$request_uri`,
 								// Server-side subrequest, so keep it in-cluster. Any *public* vouch
@@ -81,10 +82,10 @@ apps.forEach((app) => {
 				},
 				spec: {
 					tls: [{
-						hosts: [app.ingress.host],
-						secretName: `${app.name}-certificate`,
+						hosts: [ing.host],
+						secretName: `${resourceName}-certificate`,
 					}],
-					rules: [app.ingress.host].map((host) => ({
+					rules: [ing.host].map((host) => ({
 						host,
 						http: {
 							paths: [{
@@ -104,5 +105,13 @@ apps.forEach((app) => {
 				},
 			}, {provider, dependsOn: [ingress]});
 		}
+	};
+
+	if (app.targetPort) {
+		expose(app.name, app.targetPort, app.ingress);
 	}
+
+	app.extraIngresses?.forEach((extra) => {
+		expose(`${app.name}-${extra.name}`, extra.targetPort, {host: extra.host, auth: extra.auth});
+	});
 });


### PR DESCRIPTION
The agent's container now runs a virtual X display with Chromium, served
as noVNC on port 6080 (personal-agent repo), so Adam can watch or take over
a browser session. Adds an optional `extraIngresses` list to AppDefinition
for pods that need a second port behind its own hostname, factoring the
Service + Ingress creation into one helper so both paths stay identical.
Auth-gated like the viewer; x11vnc itself listens on localhost only.

Pairs with the personal-agent image change (Dockerfile + entrypoint: xvfb, openbox, x11vnc, noVNC, Chromium as a separate `desktop` uid). Only adds a Service + Ingress; the pod itself is rolled separately once the new image is published.

Recipe verified in a throwaway pod on the cluster: CDP on :9222 answers, noVNC serves on :6080, root drives the display with xdotool while Chromium runs as `desktop`.